### PR TITLE
feat: OpenAI 연동 서비스 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,8 @@ dependencies {
     runtimeOnly("org.postgresql:postgresql")
     runtimeOnly("com.h2database:h2")
 
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
+    testImplementation("io.projectreactor:reactor-test")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/src/main/kotlin/com/project/ai/domain/chat/dto/OpenAiDto.kt
+++ b/src/main/kotlin/com/project/ai/domain/chat/dto/OpenAiDto.kt
@@ -1,0 +1,39 @@
+package com.project.ai.domain.chat.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class OpenAiMessage(
+    val role: String,
+    val content: String,
+)
+
+data class OpenAiRequest(
+    val model: String,
+    val messages: List<OpenAiMessage>,
+    val stream: Boolean = false,
+)
+
+data class OpenAiResponse(
+    val choices: List<OpenAiChoice>,
+) {
+    data class OpenAiChoice(
+        val message: OpenAiMessage,
+        @JsonProperty("finish_reason")
+        val finishReason: String?,
+    )
+}
+
+data class OpenAiStreamResponse(
+    val choices: List<OpenAiStreamChoice>,
+) {
+    data class OpenAiStreamChoice(
+        val delta: OpenAiDelta,
+        @JsonProperty("finish_reason")
+        val finishReason: String?,
+    )
+
+    data class OpenAiDelta(
+        val role: String? = null,
+        val content: String? = null,
+    )
+}

--- a/src/main/kotlin/com/project/ai/domain/chat/service/OpenAiService.kt
+++ b/src/main/kotlin/com/project/ai/domain/chat/service/OpenAiService.kt
@@ -1,0 +1,106 @@
+package com.project.ai.domain.chat.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.project.ai.domain.chat.dto.OpenAiMessage
+import com.project.ai.domain.chat.dto.OpenAiRequest
+import com.project.ai.domain.chat.dto.OpenAiResponse
+import com.project.ai.domain.chat.dto.OpenAiStreamResponse
+import com.project.ai.global.error.AppException
+import com.project.ai.global.error.ErrorCode
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.codec.ServerSentEvent
+import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import org.springframework.web.reactive.function.client.bodyToFlux
+import org.springframework.web.reactive.function.client.bodyToMono
+import reactor.core.publisher.Flux
+
+@Service
+class OpenAiService(
+    private val openAiWebClient: WebClient,
+    private val objectMapper: ObjectMapper,
+    @Value("\${openai.model}") private val defaultModel: String,
+) {
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    fun chat(
+        messages: List<OpenAiMessage>,
+        model: String? = null,
+    ): String {
+        val request =
+            OpenAiRequest(
+                model = model ?: defaultModel,
+                messages = messages,
+                stream = false,
+            )
+
+        return try {
+            val response =
+                openAiWebClient
+                    .post()
+                    .uri("/v1/chat/completions")
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono<OpenAiResponse>()
+                    .block()
+                    ?: throw AppException(ErrorCode.OPENAI_API_ERROR)
+
+            response.choices
+                .firstOrNull()
+                ?.message
+                ?.content
+                ?: throw AppException(ErrorCode.OPENAI_API_ERROR)
+        } catch (e: AppException) {
+            throw e
+        } catch (e: WebClientResponseException) {
+            log.error("OpenAI API 호출 실패: status={}, body={}", e.statusCode, e.responseBodyAsString)
+            throw AppException(ErrorCode.OPENAI_API_ERROR)
+        } catch (e: Exception) {
+            log.error("OpenAI API 호출 중 예상치 못한 오류 발생", e)
+            throw AppException(ErrorCode.OPENAI_API_ERROR)
+        }
+    }
+
+    fun chatStream(
+        messages: List<OpenAiMessage>,
+        model: String? = null,
+    ): Flux<String> {
+        val request =
+            OpenAiRequest(
+                model = model ?: defaultModel,
+                messages = messages,
+                stream = true,
+            )
+
+        return openAiWebClient
+            .post()
+            .uri("/v1/chat/completions")
+            .bodyValue(request)
+            .retrieve()
+            .bodyToFlux<ServerSentEvent<String>>()
+            .filter { event ->
+                val data = event.data()
+                data != null && data != "[DONE]"
+            }
+            .map { event ->
+                try {
+                    val streamResponse = objectMapper.readValue(event.data(), OpenAiStreamResponse::class.java)
+                    streamResponse.choices.firstOrNull()?.delta?.content ?: ""
+                } catch (e: Exception) {
+                    log.warn("OpenAI 스트림 응답 파싱 실패: {}", e.message)
+                    ""
+                }
+            }
+            .filter { it.isNotEmpty() }
+            .onErrorMap { e ->
+                if (e is AppException) {
+                    e
+                } else {
+                    log.error("OpenAI 스트림 호출 중 오류 발생", e)
+                    AppException(ErrorCode.OPENAI_API_ERROR)
+                }
+            }
+    }
+}

--- a/src/main/kotlin/com/project/ai/global/config/OpenAiConfig.kt
+++ b/src/main/kotlin/com/project/ai/global/config/OpenAiConfig.kt
@@ -1,0 +1,22 @@
+package com.project.ai.global.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.web.reactive.function.client.WebClient
+
+@Configuration
+class OpenAiConfig {
+    @Bean
+    fun openAiWebClient(
+        @Value("\${openai.base-url}") baseUrl: String,
+        @Value("\${openai.api-key}") apiKey: String,
+    ): WebClient =
+        WebClient.builder()
+            .baseUrl(baseUrl)
+            .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer $apiKey")
+            .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .build()
+}

--- a/src/main/kotlin/com/project/ai/global/error/ErrorCode.kt
+++ b/src/main/kotlin/com/project/ai/global/error/ErrorCode.kt
@@ -30,6 +30,9 @@ enum class ErrorCode(
     DUPLICATE_FEEDBACK(HttpStatus.CONFLICT, "FEEDBACK_002", "이미 해당 대화에 피드백을 작성했습니다."),
     FEEDBACK_ACCESS_DENIED(HttpStatus.FORBIDDEN, "FEEDBACK_003", "피드백에 대한 접근 권한이 없습니다."),
 
+    // OpenAI
+    OPENAI_API_ERROR(HttpStatus.BAD_GATEWAY, "OPENAI_001", "AI 응답 생성에 실패했습니다."),
+
     // Validation
     VALIDATION_001(HttpStatus.BAD_REQUEST, "VALIDATION_001", "유효하지 않은 입력입니다."),
 }

--- a/src/test/kotlin/com/project/ai/domain/chat/OpenAiServiceTest.kt
+++ b/src/test/kotlin/com/project/ai/domain/chat/OpenAiServiceTest.kt
@@ -1,0 +1,211 @@
+package com.project.ai.domain.chat
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.project.ai.domain.chat.dto.OpenAiMessage
+import com.project.ai.domain.chat.service.OpenAiService
+import com.project.ai.global.error.AppException
+import com.project.ai.global.error.ErrorCode
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.test.StepVerifier
+
+class OpenAiServiceTest {
+    private lateinit var mockWebServer: MockWebServer
+    private lateinit var openAiService: OpenAiService
+    private val objectMapper =
+        ObjectMapper().registerModule(
+            KotlinModule.Builder().build(),
+        )
+
+    @BeforeEach
+    fun setUp() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+
+        val webClient =
+            WebClient.builder()
+                .baseUrl(mockWebServer.url("/").toString())
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer test-key")
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build()
+
+        openAiService = OpenAiService(webClient, objectMapper, "gpt-4o-mini")
+    }
+
+    @AfterEach
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun `chat 성공 시 응답 문자열을 반환해야 한다`() {
+        // given
+        val responseBody =
+            """
+            {
+              "choices": [
+                {
+                  "message": {
+                    "role": "assistant",
+                    "content": "안녕하세요!"
+                  },
+                  "finish_reason": "stop"
+                }
+              ]
+            }
+            """.trimIndent()
+
+        mockWebServer.enqueue(
+            MockResponse()
+                .setBody(responseBody)
+                .addHeader("Content-Type", "application/json"),
+        )
+
+        val messages = listOf(OpenAiMessage(role = "user", content = "안녕"))
+
+        // when
+        val result = openAiService.chat(messages)
+
+        // then
+        assertThat(result).isEqualTo("안녕하세요!")
+
+        val recordedRequest = mockWebServer.takeRequest()
+        assertThat(recordedRequest.path).isEqualTo("/v1/chat/completions")
+        assertThat(recordedRequest.method).isEqualTo("POST")
+
+        val requestBody = objectMapper.readTree(recordedRequest.body.readUtf8())
+        assertThat(requestBody["model"].asText()).isEqualTo("gpt-4o-mini")
+        assertThat(requestBody["stream"].asBoolean()).isFalse()
+    }
+
+    @Test
+    fun `chat에서 model 파라미터를 지정하면 해당 모델을 사용해야 한다`() {
+        // given
+        val responseBody =
+            """
+            {
+              "choices": [
+                {
+                  "message": {
+                    "role": "assistant",
+                    "content": "응답"
+                  },
+                  "finish_reason": "stop"
+                }
+              ]
+            }
+            """.trimIndent()
+
+        mockWebServer.enqueue(
+            MockResponse()
+                .setBody(responseBody)
+                .addHeader("Content-Type", "application/json"),
+        )
+
+        val messages = listOf(OpenAiMessage(role = "user", content = "테스트"))
+
+        // when
+        openAiService.chat(messages, model = "gpt-4o")
+
+        // then
+        val recordedRequest = mockWebServer.takeRequest()
+        val requestBody = objectMapper.readTree(recordedRequest.body.readUtf8())
+        assertThat(requestBody["model"].asText()).isEqualTo("gpt-4o")
+    }
+
+    @Test
+    fun `chat에서 API 오류 시 AppException을 던져야 한다`() {
+        // given
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(500)
+                .setBody("""{"error": {"message": "Internal Server Error"}}""")
+                .addHeader("Content-Type", "application/json"),
+        )
+
+        val messages = listOf(OpenAiMessage(role = "user", content = "안녕"))
+
+        // when & then
+        val exception =
+            assertThrows<AppException> {
+                openAiService.chat(messages)
+            }
+        assertThat(exception.errorCode).isEqualTo(ErrorCode.OPENAI_API_ERROR)
+    }
+
+    @Test
+    fun `chatStream 성공 시 콘텐츠 청크를 반환해야 한다`() {
+        // given
+        val sseBody =
+            """
+            data: {"choices":[{"delta":{"role":"assistant","content":"안녕"},"finish_reason":null}]}
+
+            data: {"choices":[{"delta":{"content":"하세요"},"finish_reason":null}]}
+
+            data: {"choices":[{"delta":{"content":"!"},"finish_reason":"stop"}]}
+
+            data: [DONE]
+
+            """.trimIndent()
+
+        mockWebServer.enqueue(
+            MockResponse()
+                .setBody(sseBody)
+                .addHeader("Content-Type", "text/event-stream"),
+        )
+
+        val messages = listOf(OpenAiMessage(role = "user", content = "안녕"))
+
+        // when
+        val flux = openAiService.chatStream(messages)
+
+        // then
+        StepVerifier.create(flux)
+            .expectNext("안녕")
+            .expectNext("하세요")
+            .expectNext("!")
+            .verifyComplete()
+    }
+
+    @Test
+    fun `chatStream에서 model 파라미터를 지정하면 해당 모델을 사용해야 한다`() {
+        // given
+        val sseBody =
+            """
+            data: {"choices":[{"delta":{"content":"응답"},"finish_reason":"stop"}]}
+
+            data: [DONE]
+
+            """.trimIndent()
+
+        mockWebServer.enqueue(
+            MockResponse()
+                .setBody(sseBody)
+                .addHeader("Content-Type", "text/event-stream"),
+        )
+
+        val messages = listOf(OpenAiMessage(role = "user", content = "테스트"))
+
+        // when
+        val flux = openAiService.chatStream(messages, model = "gpt-4o")
+
+        // then
+        StepVerifier.create(flux)
+            .expectNext("응답")
+            .verifyComplete()
+
+        val recordedRequest = mockWebServer.takeRequest()
+        val requestBody = objectMapper.readTree(recordedRequest.body.readUtf8())
+        assertThat(requestBody["model"].asText()).isEqualTo("gpt-4o")
+        assertThat(requestBody["stream"].asBoolean()).isTrue()
+    }
+}


### PR DESCRIPTION
## Summary
- OpenAiConfig: WebClient 빈 설정 (base-url, api-key 헤더)
- OpenAiService: 일반 응답(chat) + SSE 스트리밍(chatStream) 지원
- OpenAI 요청/응답 DTO (OpenAiMessage, OpenAiRequest, OpenAiResponse, OpenAiStreamResponse)
- ErrorCode OPENAI_API_ERROR 추가
- MockWebServer + reactor-test 테스트 의존성 추가

Closes #2

## Test plan
- [x] 정상 응답 테스트 (MockWebServer)
- [x] 커스텀 모델 파라미터 테스트
- [x] API 에러 시 AppException 발생 테스트
- [x] 스트리밍 응답 테스트
- [x] 스트리밍 커스텀 모델 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)