### PR TITLE
feat: 보고서 생성 API 구현 (CSV)

### DIFF
--- a/src/main/kotlin/com/project/ai/domain/analytics/controller/ReportController.kt
+++ b/src/main/kotlin/com/project/ai/domain/analytics/controller/ReportController.kt
@@ -1,0 +1,32 @@
+package com.project.ai.domain.analytics.controller
+
+import com.project.ai.domain.analytics.service.ReportService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+
+@RestController
+@RequestMapping("/api/v1/admin/reports")
+@Tag(name = "Reports", description = "보고서 API (관리자 전용)")
+class ReportController(
+    private val reportService: ReportService,
+) {
+    @GetMapping("/chats")
+    @Operation(summary = "대화 보고서 생성", description = "최근 24시간 대화 목록 CSV 다운로드")
+    @PreAuthorize("hasRole('ADMIN')")
+    fun generateChatReport(): ResponseEntity<ByteArray> {
+        val csv = reportService.generateChatReport()
+        val filename = "chat-report-${LocalDate.now()}.csv"
+        return ResponseEntity.ok()
+            .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"$filename\"")
+            .contentType(MediaType.parseMediaType("text/csv; charset=UTF-8"))
+            .body(csv)
+    }
+}

--- a/src/main/kotlin/com/project/ai/domain/analytics/service/ReportService.kt
+++ b/src/main/kotlin/com/project/ai/domain/analytics/service/ReportService.kt
@@ -32,7 +32,7 @@ class ReportService(
     }
 
     private fun escapeCsv(value: String): String {
-        return if (value.contains(",") || value.contains("\n") || value.contains("\"")) {
+        return if (value.contains(",") || value.contains("\n") || value.contains("\r") || value.contains("\"")) {
             "\"${value.replace("\"", "\"\"")}\""
         } else {
             value

--- a/src/main/kotlin/com/project/ai/domain/analytics/service/ReportService.kt
+++ b/src/main/kotlin/com/project/ai/domain/analytics/service/ReportService.kt
@@ -1,0 +1,41 @@
+package com.project.ai.domain.analytics.service
+
+import com.project.ai.domain.chat.repository.ChatRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service
+@Transactional(readOnly = true)
+class ReportService(
+    private val chatRepository: ChatRepository,
+) {
+    fun generateChatReport(): ByteArray {
+        val oneDayAgo = LocalDateTime.now().minusDays(1)
+        val chats = chatRepository.findAllWithUserAfter(oneDayAgo)
+
+        val sb = StringBuilder()
+        // UTF-8 BOM
+        sb.append('\uFEFF')
+        // Header
+        sb.appendLine("사용자이메일,사용자이름,질문,답변,생성일시")
+
+        for (chat in chats) {
+            val user = chat.thread.user
+            sb.appendLine(
+                "${escapeCsv(user.email)},${escapeCsv(user.name)}," +
+                    "${escapeCsv(chat.question)},${escapeCsv(chat.answer)},${chat.createdAt}",
+            )
+        }
+
+        return sb.toString().toByteArray(Charsets.UTF_8)
+    }
+
+    private fun escapeCsv(value: String): String {
+        return if (value.contains(",") || value.contains("\n") || value.contains("\"")) {
+            "\"${value.replace("\"", "\"\"")}\""
+        } else {
+            value
+        }
+    }
+}

--- a/src/main/kotlin/com/project/ai/domain/chat/repository/ChatRepository.kt
+++ b/src/main/kotlin/com/project/ai/domain/chat/repository/ChatRepository.kt
@@ -6,8 +6,17 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
+import java.time.LocalDateTime
 
 interface ChatRepository : JpaRepository<Chat, Long> {
+    @Query(
+        "SELECT c FROM Chat c JOIN FETCH c.thread t JOIN FETCH t.user " +
+            "WHERE c.createdAt > :after ORDER BY c.createdAt ASC",
+    )
+    fun findAllWithUserAfter(
+        @Param("after") after: LocalDateTime,
+    ): List<Chat>
+
     fun findAllByThreadOrderByCreatedAtAsc(thread: Thread): List<Chat>
 
     fun findAllByThreadIdOrderByCreatedAtAsc(threadId: Long): List<Chat>

--- a/src/test/kotlin/com/project/ai/domain/analytics/ReportServiceTest.kt
+++ b/src/test/kotlin/com/project/ai/domain/analytics/ReportServiceTest.kt
@@ -1,0 +1,142 @@
+package com.project.ai.domain.analytics
+
+import com.project.ai.domain.analytics.service.ReportService
+import com.project.ai.domain.chat.entity.Chat
+import com.project.ai.domain.chat.entity.Thread
+import com.project.ai.domain.chat.repository.ChatRepository
+import com.project.ai.domain.user.entity.User
+import com.project.ai.global.common.BaseTimeEntity
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import java.time.LocalDateTime
+
+@ExtendWith(MockitoExtension::class)
+class ReportServiceTest {
+    @Mock
+    private lateinit var chatRepository: ChatRepository
+
+    @InjectMocks
+    private lateinit var reportService: ReportService
+
+    private fun createUser(
+        email: String = "test@test.com",
+        name: String = "테스터",
+    ): User = User(id = 1L, email = email, password = "encoded", name = name)
+
+    private fun createThread(user: User): Thread = Thread(id = 1L, user = user)
+
+    private fun setCreatedAt(
+        entity: BaseTimeEntity,
+        time: LocalDateTime,
+    ) {
+        val field = BaseTimeEntity::class.java.getDeclaredField("createdAt")
+        field.isAccessible = true
+        field.set(entity, time)
+    }
+
+    private fun createChat(
+        thread: Thread,
+        question: String = "질문",
+        answer: String = "답변",
+        createdAt: LocalDateTime = LocalDateTime.now(),
+    ): Chat {
+        val chat = Chat(id = 1L, thread = thread, question = question, answer = answer)
+        setCreatedAt(chat, createdAt)
+        return chat
+    }
+
+    @Test
+    fun `데이터가 있으면 올바른 CSV를 생성해야 한다`() {
+        // given
+        val user = createUser(email = "user@test.com", name = "홍길동")
+        val thread = createThread(user)
+        val now = LocalDateTime.of(2026, 3, 17, 10, 0, 0)
+        val chat = createChat(thread, question = "안녕하세요", answer = "반갑습니다", createdAt = now)
+
+        given(chatRepository.findAllWithUserAfter(any<LocalDateTime>())).willReturn(listOf(chat))
+
+        // when
+        val result = reportService.generateChatReport()
+        val csv = String(result, Charsets.UTF_8)
+
+        // then
+        assertThat(csv).startsWith("\uFEFF")
+        assertThat(csv).contains("사용자이메일,사용자이름,질문,답변,생성일시")
+        assertThat(csv).contains("user@test.com,홍길동,안녕하세요,반갑습니다,2026-03-17T10:00")
+    }
+
+    @Test
+    fun `데이터가 없으면 헤더만 포함된 CSV를 반환해야 한다`() {
+        // given
+        given(chatRepository.findAllWithUserAfter(any<LocalDateTime>())).willReturn(emptyList())
+
+        // when
+        val result = reportService.generateChatReport()
+        val csv = String(result, Charsets.UTF_8)
+
+        // then
+        assertThat(csv).startsWith("\uFEFF")
+        assertThat(csv).contains("사용자이메일,사용자이름,질문,답변,생성일시")
+        val lines = csv.trim().lines()
+        assertThat(lines).hasSize(1) // BOM + header only
+    }
+
+    @Test
+    fun `CSV에서 쉼표, 따옴표, 줄바꿈이 올바르게 이스케이프되어야 한다`() {
+        // given
+        val user = createUser(email = "user@test.com", name = "홍,길동")
+        val thread = createThread(user)
+        val now = LocalDateTime.of(2026, 3, 17, 10, 0, 0)
+        val chatWithComma = createChat(thread, question = "안녕,하세요", answer = "반갑습니다", createdAt = now)
+
+        val user2 = createUser(email = "user2@test.com", name = "김\"철수")
+        val thread2 = Thread(id = 2L, user = user2)
+        val chatWithQuote =
+            Chat(id = 2L, thread = thread2, question = "질문입니다", answer = "답\"변")
+        setCreatedAt(chatWithQuote, now)
+
+        val user3 = createUser(email = "user3@test.com", name = "박영희")
+        val thread3 = Thread(id = 3L, user = user3)
+        val chatWithNewline =
+            Chat(id = 3L, thread = thread3, question = "줄바꿈\n질문", answer = "답변")
+        setCreatedAt(chatWithNewline, now)
+
+        given(chatRepository.findAllWithUserAfter(any<LocalDateTime>()))
+            .willReturn(listOf(chatWithComma, chatWithQuote, chatWithNewline))
+
+        // when
+        val result = reportService.generateChatReport()
+        val csv = String(result, Charsets.UTF_8)
+
+        // then
+        // 쉼표가 포함된 값은 따옴표로 감싸져야 한다
+        assertThat(csv).contains("\"홍,길동\"")
+        assertThat(csv).contains("\"안녕,하세요\"")
+        // 따옴표가 포함된 값은 따옴표를 이중으로 이스케이프해야 한다
+        assertThat(csv).contains("\"김\"\"철수\"")
+        assertThat(csv).contains("\"답\"\"변\"")
+        // 줄바꿈이 포함된 값은 따옴표로 감싸져야 한다
+        assertThat(csv).contains("\"줄바꿈\n질문\"")
+    }
+
+    @Test
+    fun `UTF-8 BOM이 존재해야 한다`() {
+        // given
+        given(chatRepository.findAllWithUserAfter(any<LocalDateTime>())).willReturn(emptyList())
+
+        // when
+        val result = reportService.generateChatReport()
+
+        // then
+        // UTF-8 BOM: EF BB BF
+        assertThat(result[0]).isEqualTo(0xEF.toByte())
+        assertThat(result[1]).isEqualTo(0xBB.toByte())
+        assertThat(result[2]).isEqualTo(0xBF.toByte())
+    }
+}


### PR DESCRIPTION
## Summary
- `GET /api/v1/admin/reports/chats`: 24시간 내 대화 CSV 다운로드 (관리자 전용)
- UTF-8 BOM + RFC 4180 CSV 이스케이프
- JOIN FETCH로 N+1 방지
- @PreAuthorize("hasRole('ADMIN')") 권한 제어

Closes #11

## Test plan
- [x] CSV 데이터 정확성
- [x] 빈 데이터 시 헤더만 반환
- [x] 특수문자(쉼표, 따옴표, 줄바꿈) 이스케이프
- [x] UTF-8 BOM 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)