### PR TITLE
fix: OpenAI 서비스 안정성 개선

### DIFF
--- a/src/main/kotlin/com/project/ai/domain/chat/service/OpenAiService.kt
+++ b/src/main/kotlin/com/project/ai/domain/chat/service/OpenAiService.kt
@@ -12,10 +12,13 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.codec.ServerSentEvent
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientRequestException
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import org.springframework.web.reactive.function.client.bodyToFlux
 import org.springframework.web.reactive.function.client.bodyToMono
 import reactor.core.publisher.Flux
+import java.time.Duration
+import java.util.concurrent.TimeoutException
 
 @Service
 class OpenAiService(
@@ -24,6 +27,11 @@ class OpenAiService(
     @Value("\${openai.model}") private val defaultModel: String,
 ) {
     private val log = LoggerFactory.getLogger(this::class.java)
+
+    companion object {
+        private val REQUEST_TIMEOUT: Duration = Duration.ofSeconds(30)
+        private const val MAX_STREAM_PARSE_FAILURES = 5
+    }
 
     fun chat(
         messages: List<OpenAiMessage>,
@@ -44,6 +52,7 @@ class OpenAiService(
                     .bodyValue(request)
                     .retrieve()
                     .bodyToMono<OpenAiResponse>()
+                    .timeout(REQUEST_TIMEOUT)
                     .block()
                     ?: throw AppException(ErrorCode.OPENAI_API_ERROR)
 
@@ -57,8 +66,14 @@ class OpenAiService(
         } catch (e: WebClientResponseException) {
             log.error("OpenAI API 호출 실패: status={}, body={}", e.statusCode, e.responseBodyAsString)
             throw AppException(ErrorCode.OPENAI_API_ERROR)
-        } catch (e: Exception) {
-            log.error("OpenAI API 호출 중 예상치 못한 오류 발생", e)
+        } catch (e: WebClientRequestException) {
+            log.error("OpenAI API 연결 실패: {}", e.message)
+            throw AppException(ErrorCode.OPENAI_API_ERROR)
+        } catch (e: TimeoutException) {
+            log.error("OpenAI API 타임아웃: {}ms 초과", REQUEST_TIMEOUT.toMillis())
+            throw AppException(ErrorCode.OPENAI_API_ERROR)
+        } catch (e: IllegalStateException) {
+            log.error("OpenAI API 응답 처리 중 오류: {}", e.message)
             throw AppException(ErrorCode.OPENAI_API_ERROR)
         }
     }
@@ -74,6 +89,8 @@ class OpenAiService(
                 stream = true,
             )
 
+        var parseFailureCount = 0
+
         return openAiWebClient
             .post()
             .uri("/v1/chat/completions")
@@ -88,8 +105,12 @@ class OpenAiService(
                 try {
                     val streamResponse = objectMapper.readValue(event.data(), OpenAiStreamResponse::class.java)
                     streamResponse.choices.firstOrNull()?.delta?.content ?: ""
-                } catch (e: Exception) {
-                    log.warn("OpenAI 스트림 응답 파싱 실패: {}", e.message)
+                } catch (e: com.fasterxml.jackson.core.JsonProcessingException) {
+                    parseFailureCount++
+                    log.warn("OpenAI 스트림 응답 파싱 실패 ({}/{}): {}", parseFailureCount, MAX_STREAM_PARSE_FAILURES, e.message)
+                    if (parseFailureCount >= MAX_STREAM_PARSE_FAILURES) {
+                        throw AppException(ErrorCode.OPENAI_API_ERROR)
+                    }
                     ""
                 }
             }

--- a/src/main/kotlin/com/project/ai/global/config/OpenAiConfig.kt
+++ b/src/main/kotlin/com/project/ai/global/config/OpenAiConfig.kt
@@ -1,11 +1,16 @@
 package com.project.ai.global.config
 
+import io.netty.channel.ChannelOption
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
+import org.springframework.http.client.reactive.ReactorClientHttpConnector
+import org.springframework.web.reactive.function.client.ExchangeStrategies
 import org.springframework.web.reactive.function.client.WebClient
+import reactor.netty.http.client.HttpClient
+import java.time.Duration
 
 @Configuration
 class OpenAiConfig {
@@ -13,10 +18,23 @@ class OpenAiConfig {
     fun openAiWebClient(
         @Value("\${openai.base-url}") baseUrl: String,
         @Value("\${openai.api-key}") apiKey: String,
-    ): WebClient =
-        WebClient.builder()
+    ): WebClient {
+        val httpClient =
+            HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10_000)
+                .responseTimeout(Duration.ofSeconds(60))
+
+        val exchangeStrategies =
+            ExchangeStrategies.builder()
+                .codecs { it.defaultCodecs().maxInMemorySize(1024 * 1024) }
+                .build()
+
+        return WebClient.builder()
             .baseUrl(baseUrl)
             .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer $apiKey")
             .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .clientConnector(ReactorClientHttpConnector(httpClient))
+            .exchangeStrategies(exchangeStrategies)
             .build()
+    }
 }


### PR DESCRIPTION
## Summary
4개 이슈를 한번에 해결합니다.

- **#18** `chat()` 요청에 30초 timeout 추가 (`.timeout(Duration.ofSeconds(30))`)
- **#19** `catch(Exception)` → `WebClientRequestException`, `TimeoutException`, `IllegalStateException` 등 구체적 예외 분리
- **#20** 스트림 파싱 실패 카운트 추적, 5회 이상 시 에러 전환. `JsonProcessingException`으로 구체적 예외 처리
- **#21** WebClient `maxInMemorySize` 1MB, connection timeout 10s, response timeout 60s 설정

Closes #18
Closes #19
Closes #20
Closes #21

## Test plan
- [x] 기존 OpenAiServiceTest 전체 통과 확인
- [x] chat 성공/실패/모델선택 테스트
- [x] chatStream 성공/모델선택 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)